### PR TITLE
Remove check for attribution links

### DIFF
--- a/youtube.lua
+++ b/youtube.lua
@@ -813,9 +813,9 @@ wget.callbacks.get_urls = function(file, url, is_css, iri)
     for s in string.gmatch(html, "[%?&]list=(" .. playlist_pattern .. ")") do
       queue_item("p", s)
     end
-    if string.match(html, "/attribution%?v=" .. item_value) then
+    --[[if string.match(html, "/attribution%?v=" .. item_value) then
       check("https://www.youtube.com/attribution?v=" .. item_value)
-    end
+    end]]
     -- TODO
     --[[for newurl in string.gmatch(string.gsub(html, "&quot;", '"'), '([^"]+)') do
       checknewurl(newurl)


### PR DESCRIPTION
Attribution links are still present below descriptions but return HTTP 410 when accessed. This untested PR removes the check for attribution links.