### PR TITLE
use https for all AT services

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -69,7 +69,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20241119.01'
+VERSION = '20241127.01'
 USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
 TRACKER_ID = 'youtube'
 TRACKER_HOST = 'legacy-api.arpa.li'


### PR DESCRIPTION
https was used inconsistently for links (especially to the tracker)